### PR TITLE
pyhacrf-datamade 0.2.7 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - https://staging.continuum.io/prefect/fs/pylbfgs-feedstock/pr2/7eff0ab

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - https://staging.continuum.io/prefect/fs/pylbfgs-feedstock/pr2/7eff0ab

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyhacrf-datamade" %}
-{% set version = "0.2.6" %}
+{% set version = "0.2.7" %}
 
 
 package:
@@ -8,12 +8,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyhacrf-datamade-{{ version }}.tar.gz
-  sha256: cddbd89aad5849fb8fba6f93bfea177fd02dba1b81718fd215f57b48d3d6f5ed
+  sha256: 6e898ab725af37337773fc2076d617255f64db018f2dd486b9e4f8ecda15cfed
 
 build:
-  number: 2
+  number: 0
   skip: true  # [win]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -23,6 +23,8 @@ requirements:
     - numpy
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - pylbfgs
     - python
@@ -31,16 +33,22 @@ requirements:
 test:
   imports:
     - pyhacrf
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/dedupeio/pyhacrf
-  summary: Hidden alignment conditional random field, a discriminative string edit distance
+  summary: Hidden alignment conditional random field for classifying string pairs.
+  description: |
+    Hidden alignment conditional random field for classifying string
+    pairs - a learnable edit distance.
   license: BSD-3-Clause
   license_file: LICENSE
+  license_family: BSD
+  doc_url: https://github.com/dedupeio/pyhacrf
+  dev_url: https://github.com/dedupeio/pyhacrf
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,9 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyhacrf-datamade-{{ version }}.tar.gz
-  sha256: 6e898ab725af37337773fc2076d617255f64db018f2dd486b9e4f8ecda15cfed
+  # Use upstream archive tarball for tests
+  url: https://github.com/datamade/pyhacrf/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: df59476f6f46e19f1197af517ce25f6c991ae427af7aff43f8e640b535763d12
 
 build:
   number: 0
@@ -19,23 +20,27 @@ requirements:
     - {{ compiler('c') }}
   host:
     - cython
-    - numpy
+    - numpy {{ numpy }}
     - pip
     - python
     - setuptools
     - wheel
   run:
-    - pylbfgs
+    - pylbfgs >=0.1.3
     - python
     - {{ pin_compatible('numpy') }}
 
 test:
+  source_files:
+    - pyhacrf/tests
   imports:
     - pyhacrf
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v pyhacrf/tests
 
 about:
   home: https://github.com/dedupeio/pyhacrf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,9 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest -v pyhacrf/tests
+    - pytest -v pyhacrf/tests                               # [not linux-64]
+    # AssertionError: -2.0 != -1.9999999999999998
+    - pytest -v pyhacrf/tests -k "not test_forward_single"  # [linux-64]
 
 about:
   home: https://github.com/dedupeio/pyhacrf


### PR DESCRIPTION
pyhacrf-datamade 0.2.7 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4968]
- dev_url:        https://github.com/datamade/pyhacrf/tree/v0.2.7
- conda_forge:    https://github.com/conda-forge/pyhacrf-datamade-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/pyhacrf-datamade/0.2.7
- pypi inspector: https://inspector.pypi.io/project/pyhacrf-datamade/0.2.7

### Explanation of changes:

- basic build
- remove (conda-forge) skip for `[win]`
- add upstream tests
- skip an AssertionError on `linux-64` (floating point comparisons again)


[PKG-4968]: https://anaconda.atlassian.net/browse/PKG-4968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ